### PR TITLE
Fix/exemplo-contratos

### DIFF
--- a/exemplos-contratos/RealDigital.sol
+++ b/exemplos-contratos/RealDigital.sol
@@ -40,7 +40,7 @@ contract RealDigital is ERC20, CBDCAccessControl, Pausable {
     // e permite que a transferência seja pausada.
     function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
         super._beforeTokenTransfer(from, to, amount);
-        if (from != address(0)) { // Not a minting operation
+        if (from != address(0) && to != address(0)) { // Not a minting or burning operation
             require(!paused(), "Token transfer while paused");
             require(hasRole(ACCESS_ROLE, from), "Caller is not a participant");
             require(hasRole(ACCESS_ROLE, to), "Receiver is not a participant");

--- a/exemplos-contratos/RealTokenizado.sol
+++ b/exemplos-contratos/RealTokenizado.sol
@@ -13,8 +13,6 @@ contract RealTokenizado is RealDigital {
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant RESERVE_ROLE = keccak256("RESERVE_ROLE");
     
-    mapping(address => uint256) private _frozenBalances;
-
     string public participant;
     uint256 public cnpj8;
     address public reserve;


### PR DESCRIPTION
Remove o mapping duplicado de Real Tokenizado e corrige função _beforeTokenTransfer dentro de Real Digital